### PR TITLE
added support for Mattermost

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 MantisBT-Slack
 ==============
 
-A [MantisBT](http://www.mantisbt.org/) plugin to send bug updates to [Slack](https://slack.com/) channels.
+A [MantisBT](http://www.mantisbt.org/) plugin to send bug updates to [Slack](https://slack.com/) and [Mattermost](https://about.mattermost.com/) channels.
 
 
 # Setup

--- a/Slack.php
+++ b/Slack.php
@@ -291,8 +291,8 @@ class SlackPlugin extends MantisPlugin {
         if ($attachment) {
             $payload['attachments'] = array($attachment);
         }
-        $data = array('payload' => json_encode($payload));
-        curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
+
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($payload));
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
         curl_setopt($ch, CURLOPT_TIMEOUT, 5);
         $result = curl_exec($ch);


### PR DESCRIPTION
Mattermost failed at parsing if wrapped in the array. 
But it seems like Slack is more forgiving in that point. 

fixes #35 