### PR TITLE
Minimalist fix to allow for correct Slack username mentions.

### DIFF
--- a/Slack.php
+++ b/Slack.php
@@ -414,6 +414,6 @@ class SlackPlugin extends MantisPlugin {
     	$username = $user['username'];
         $usernames = plugin_config_get('usernames');
         $username = array_key_exists($username, $usernames) ? $usernames[$username] : $username;
-		return '@' . $username;
+	return '<@' . $username . '>';
     }
 }


### PR DESCRIPTION
Slack deprecated and ultimately stopped supporting user references in the `@displayname` syntax in 2018. References now must be provided in the `<@MemberID>` format (eg. `<@UEX823F38L>`)

This fix applies the required parentheses. Correct operation will require the appropriate mapping of mantis username => slack member IDs in `Manage Configuration` => `Configuration Report` => `Database Configuration` => `plugin_Slack_usernames`

Fixes #10 
